### PR TITLE
feat: add camera collision and movement tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-# React + Vite
+# juribly-web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Frontend for the Juribly courtroom prototype built with Vite and React.
 
-Currently, two official plugins are available:
+## Scripts
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm dev
+```
 
-## Expanding the ESLint configuration
+## Test Arena
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+`src/scene/TestArena.jsx` provides a minimal floor-and-walls scene used to
+validate camera collision and no-through-floor behaviour.
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -32,6 +34,9 @@
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.10",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.4",
     "vite": "^7.1.2"
   }
 }
+

--- a/src/controls/AudienceFreecam.jsx
+++ b/src/controls/AudienceFreecam.jsx
@@ -5,6 +5,7 @@ import * as THREE from "three";
 import React, { useEffect, useMemo, useRef } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import { gatherColliders, keepAboveGround, sweepAndSlide } from "./CameraCollision";
+import { clamp, damp } from "../lib/math";
 
 const _next = new THREE.Vector3();
 const _move = new THREE.Vector3();
@@ -44,8 +45,8 @@ export default function AudienceFreecam({ enabled = true, start = new THREE.Vect
       yaw.current -= dx * 0.0025;
       pitch.current -= dy * 0.0025;
       // clamp pitch to avoid flipping
-      const lim = THREE.MathUtils.degToRad(85);
-      pitch.current = Math.max(-lim, Math.min(lim, pitch.current));
+      const lim = THREE.MathUtils.degToRad(80);
+      pitch.current = clamp(pitch.current, -lim, lim);
     };
     const onClick = () => {
       if (document.pointerLockElement !== dom) dom.requestPointerLock();
@@ -95,9 +96,11 @@ export default function AudienceFreecam({ enabled = true, start = new THREE.Vect
     keepAboveGround(_next, colliders, 0.05);
 
     // Smooth camera to target to avoid jitter
-    camera.position.lerp(_next, 1 - Math.exp(-SMOOTH * dt));
-    camera.quaternion.slerp(q, 1 - Math.exp(-SMOOTH * dt));
+    const s = damp(0, 1, SMOOTH, dt);
+    camera.position.lerp(_next, s);
+    camera.quaternion.slerp(q, s);
   });
 
   return null;
 }
+

--- a/src/controls/CameraCollision.test.js
+++ b/src/controls/CameraCollision.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { sweepAndSlide, keepAboveGround } from './CameraCollision';
+
+describe('camera collision', () => {
+  it('keeps position above floor', () => {
+    const floor = new THREE.Mesh(
+      new THREE.PlaneGeometry(10, 10),
+      new THREE.MeshBasicMaterial()
+    );
+    floor.rotateX(-Math.PI / 2);
+    floor.userData.collidable = true;
+    const colliders = [floor];
+
+    const prev = new THREE.Vector3(0, 1, 0);
+    const next = new THREE.Vector3(0, -1, 0);
+    sweepAndSlide(prev, next, colliders, 0.35, 2);
+    keepAboveGround(next, colliders, 0);
+
+    expect(next.y).toBeGreaterThanOrEqual(0);
+  });
+});
+

--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -1,0 +1,25 @@
+// math.js
+// Shared math utilities for damping and clamping.
+
+/**
+ * Clamp a value between min and max.
+ * @param {number} v
+ * @param {number} min
+ * @param {number} max
+ */
+export function clamp(v, min, max) {
+  return Math.max(min, Math.min(max, v));
+}
+
+/**
+ * Exponential damping towards a target value.
+ * Returns the interpolated value at time dt with rate lambda.
+ * @param {number} from
+ * @param {number} to
+ * @param {number} lambda
+ * @param {number} dt
+ */
+export function damp(from, to, lambda, dt) {
+  return from + (to - from) * (1 - Math.exp(-lambda * dt));
+}
+

--- a/src/lib/math.test.js
+++ b/src/lib/math.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { clamp, damp } from './math';
+
+describe('math utilities', () => {
+  it('clamp limits values within range', () => {
+    expect(clamp(5, 0, 3)).toBe(3);
+    expect(clamp(-1, 0, 3)).toBe(0);
+    expect(clamp(2, 0, 3)).toBe(2);
+  });
+
+  it('damp approaches target value', () => {
+    const v = damp(0, 10, 5, 0.1);
+    expect(v).toBeGreaterThan(0);
+    expect(v).toBeLessThan(10);
+  });
+});
+

--- a/src/scene/TestArena.jsx
+++ b/src/scene/TestArena.jsx
@@ -1,0 +1,35 @@
+// TestArena.jsx
+// Minimal arena with floor and walls for manual collision testing.
+
+import React from 'react';
+
+export default function TestArena() {
+  return (
+    <group>
+      {/* Floor */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} userData={{ collidable: true }}>
+        <planeGeometry args={[20, 20]} />
+        <meshStandardMaterial color="#777" />
+      </mesh>
+
+      {/* Walls */}
+      <mesh position={[0, 1, -10]} userData={{ collidable: true }}>
+        <boxGeometry args={[20, 2, 1]} />
+        <meshStandardMaterial color="#555" />
+      </mesh>
+      <mesh position={[0, 1, 10]} userData={{ collidable: true }}>
+        <boxGeometry args={[20, 2, 1]} />
+        <meshStandardMaterial color="#555" />
+      </mesh>
+      <mesh position={[10, 1, 0]} userData={{ collidable: true }}>
+        <boxGeometry args={[1, 2, 20]} />
+        <meshStandardMaterial color="#555" />
+      </mesh>
+      <mesh position={[-10, 1, 0]} userData={{ collidable: true }}>
+        <boxGeometry args={[1, 2, 20]} />
+        <meshStandardMaterial color="#555" />
+      </mesh>
+    </group>
+  );
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": false,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}
+


### PR DESCRIPTION
## Summary
- prevent freecam from pitching past +/-80° and smooth camera motion
- sweep-and-slide player movement with ground clamp
- add basic math utilities, unit tests and minimal arena scene

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Freact-dom: Forbidden - 403)*
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm typecheck` *(fails: Cannot find global value 'Promise')*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c673485a2c8328a627250012bd87b2