### PR TITLE
feat: add ability to start new trials

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
   },
   "dependencies": {
     "@react-three/drei": "^10.7.5",
@@ -32,6 +34,9 @@
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.10",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^16.0.0",
+    "typescript": "^5.6.2"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -252,7 +252,7 @@ export default function App() {
               <span style={{ opacity: 0.6 }}>Trial: {activeTrialId || "—"}</span>
             </div>
 
-            <CourtroomShell trialId={activeTrialId} role={role} currentProfile={currentProfile} />
+            <CourtroomShell trialId={activeTrialId} role={role} currentProfile={currentProfile} onNewTrial={(id)=>setActiveTrialId(id)} />
           </div>
         )}
       </div>

--- a/src/components/CourtroomShell.jsx
+++ b/src/components/CourtroomShell.jsx
@@ -6,8 +6,8 @@ import CourtroomScene from "../3d/CourtroomScene.jsx";
 import RemoteCrowd from "./RemoteCrowd.jsx";
 import useMultiplayer from "../hooks/useMultiplayer.js";
 
-export default function CourtroomShell({ trialId="demo-1", role="Audience", currentProfile=null }) {
-  const { connected, self, others, joinRoom, updatePose } = useMultiplayer();
+export default function CourtroomShell({ trialId="demo-1", role="Audience", currentProfile=null, onNewTrial=null }) {
+  const { connected, self, others, joinRoom, updatePose, startTrial } = useMultiplayer();
   const selfSocketId = useRef(null);
   const name = currentProfile?.display_name || currentProfile?.handle || "Guest";
   const handle = currentProfile?.handle || null;
@@ -23,8 +23,19 @@ export default function CourtroomShell({ trialId="demo-1", role="Audience", curr
 
   return (
     <div style={{ position: "relative", height: "70vh", border: "1px solid #e5e7eb", borderRadius: 12, overflow: "hidden", background: "#0b0b0b" }}>
-      <div style={{ position: "absolute", zIndex: 10, top: 8, left: 8, fontSize: 12, color: connected ? "#16a34a" : "#ef4444" }}>
+      <div style={{ position: "absolute", zIndex: 10, top: 8, left: 8, fontSize: 12, color: connected ? "#16a34a" : "#ef4444", display: "flex", gap: 6, alignItems: "center" }}>
         {connected ? "● connected" : "○ offline"} — trial <b>{trialId}</b>
+        {role === "Judge" && (
+          <button
+            onClick={async () => {
+              const id = await startTrial();
+              if (id) onNewTrial?.(id);
+            }}
+            style={{ padding: "2px 6px", borderRadius: 4, border: "1px solid #ccc", background: "#fff", color: "#000", fontSize: 12 }}
+          >
+            New Trial
+          </button>
+        )}
       </div>
       <Canvas shadows dpr={[1, 2]} camera={{ position: [0, 2.5, 6], fov: 50 }}>
         {/* lights */}

--- a/src/hooks/useMultiplayer.test.js
+++ b/src/hooks/useMultiplayer.test.js
@@ -1,0 +1,31 @@
+// juribly-web/src/hooks/useMultiplayer.test.js
+import { renderHook, act } from "@testing-library/react";
+import { vi, expect, test } from "vitest";
+
+const listeners = {};
+const mockSocket = {
+  connected: true,
+  emit: vi.fn((evt, payload, cb) => {
+    if (evt === "startTrial") cb && cb({ trialId: "trial-new" });
+  }),
+  on: vi.fn((evt, cb) => { listeners[evt] = cb; }),
+  off: vi.fn((evt) => { delete listeners[evt]; }),
+  connect: vi.fn(),
+};
+vi.mock("../lib/socket.js", () => ({ default: mockSocket }));
+
+import useMultiplayer from "./useMultiplayer.js";
+
+test("startTrial resets participants and returns new id", async () => {
+  const { result } = renderHook(() => useMultiplayer());
+  await act(() => {
+    listeners["presence:state"]?.({ participants: [{ socketId: "a" }] });
+  });
+  expect(result.current.participants.size).toBe(1);
+  let id;
+  await act(async () => {
+    id = await result.current.startTrial();
+  });
+  expect(id).toBe("trial-new");
+  expect(result.current.participants.size).toBe(0);
+});


### PR DESCRIPTION
## Summary
- allow judges to start new trials and show ID
- reset courtroom state on trial change
- cover trial reset logic with a unit test

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Freact: Forbidden - 403)*
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm typecheck` *(fails: Command failed with exit code 1)*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67c187ee88328bfbeb0e2e56e39ea